### PR TITLE
added commented out workarounds for openssl 3, lan noroute plus server list parse fix

### DIFF
--- a/fastIPvanish
+++ b/fastIPvanish
@@ -347,7 +347,7 @@ update_server_list() {
             rm -rf "$vpn_server_list"
             # Read and parse results from the temp file
             while IFS='' read -r line || [[ -n "$line" ]] ; do
-                awk -F'"' '/ipvanish-/{print substr($2, 10, length($2)-14)}' $list \
+                awk -F'>' '/ipvanish-/{print substr($2, 11, length($2)-16)}' $list \
                     >> "$vpn_server_list"
             done < "$temp_file"
             echo " Done";

--- a/templates/default.tmpl
+++ b/templates/default.tmpl
@@ -21,4 +21,8 @@ verb 3
 auth SHA256
 cipher AES-256-CBC
 keysize 256
+#fix for openssl 3 systems connecting to VPNs that haven't updated their certs! (note, risk involved)
+#tls-cipher DEFAULT:@SECLEVEL=0
 tls-cipher TLS-DHE-RSA-WITH-AES-256-CBC-SHA:TLS-DHE-DSS-WITH-AES-256-CBC-SHA:TLS-RSA-WITH-AES-256-CBC-SHA
+#don't route my lan example, put gateway (router) at end
+#route 192.168.1.0 255.255.255.0 192.168.50.1


### PR DESCRIPTION
With latest Ubuntu 22.04 LTS and associated forks -- namely, the introduction of openssl 3.x. VPN providers (including ipvanish) are slow to adopt and rollout CA cert changes for their services and thus, openssl 3 "sees" weak algorithms, and kills connection with fatal error. I've included a temp workaround for those that need it on systems with openssl 3.x -- as a comment to the default template. NOTE YOU MUST ACCEPT RISK if uncommenting/enabling:

```
tls-cipher DEFAULT:@SECLEVEL=0
```
Setting the security level to zero will not disable the encryption but it provides backward compatibility which means the use of certificates that have smaller security key length will be allowed.

In addition I've added a helpful (commented out) workaround for folks who don't want their lan access traffic to travel or attempt to travel over VPN.

Finally, ipvanish changed their server list output/html page and I fixed the awk that was parsing the server names if you ran fastIPvanish -u (to update server list)